### PR TITLE
Change work session worked paths to equipment log files

### DIFF
--- a/lib/src/features/common/providers/file_providers.g.dart
+++ b/lib/src/features/common/providers/file_providers.g.dart
@@ -6,7 +6,7 @@ part of 'file_providers.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$fileDirectoryHash() => r'e6a3328b4716ad17d353e807dafbdc48ff31f5f1';
+String _$fileDirectoryHash() => r'0d7bbbb97993af78abe5df58d8a641a45423d458';
 
 /// A provider for the main user file directory for the application.
 ///
@@ -432,7 +432,7 @@ class _DirectoryDeleteProviderElement
 }
 
 String _$saveJsonToFileDirectoryHash() =>
-    r'7ee46aec60cf860a7e03eb8f946c4e70785ecd71';
+    r'ac389047f30dd98e9fb4f0695a7ea38ef7299fa8';
 
 /// A provider for saving [object] to [fileName].json to a file in the [folder]
 /// in the file drectory.
@@ -482,12 +482,14 @@ class SaveJsonToFileDirectoryFamily extends Family {
     required dynamic object,
     required String fileName,
     required String folder,
+    String? subFolder,
     bool downloadIfWeb = false,
   }) {
     return SaveJsonToFileDirectoryProvider(
       object: object,
       fileName: fileName,
       folder: folder,
+      subFolder: subFolder,
       downloadIfWeb: downloadIfWeb,
     );
   }
@@ -501,6 +503,7 @@ class SaveJsonToFileDirectoryFamily extends Family {
       object: provider.object,
       fileName: provider.fileName,
       folder: provider.folder,
+      subFolder: provider.subFolder,
       downloadIfWeb: provider.downloadIfWeb,
     );
   }
@@ -545,6 +548,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
     required dynamic object,
     required String fileName,
     required String folder,
+    String? subFolder,
     bool downloadIfWeb = false,
   }) : this._internal(
           (ref) => saveJsonToFileDirectory(
@@ -552,6 +556,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
             object: object,
             fileName: fileName,
             folder: folder,
+            subFolder: subFolder,
             downloadIfWeb: downloadIfWeb,
           ),
           from: saveJsonToFileDirectoryProvider,
@@ -566,6 +571,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
           object: object,
           fileName: fileName,
           folder: folder,
+          subFolder: subFolder,
           downloadIfWeb: downloadIfWeb,
         );
 
@@ -579,12 +585,14 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
     required this.object,
     required this.fileName,
     required this.folder,
+    required this.subFolder,
     required this.downloadIfWeb,
   }) : super.internal();
 
   final dynamic object;
   final String fileName;
   final String folder;
+  final String? subFolder;
   final bool downloadIfWeb;
 
   @override
@@ -603,6 +611,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
         object: object,
         fileName: fileName,
         folder: folder,
+        subFolder: subFolder,
         downloadIfWeb: downloadIfWeb,
       ),
     );
@@ -613,12 +622,14 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
     dynamic object,
     String fileName,
     String folder,
+    String? subFolder,
     bool downloadIfWeb,
   }) get argument {
     return (
       object: object,
       fileName: fileName,
       folder: folder,
+      subFolder: subFolder,
       downloadIfWeb: downloadIfWeb,
     );
   }
@@ -641,6 +652,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
       object: object,
       fileName: fileName,
       folder: folder,
+      subFolder: subFolder,
       downloadIfWeb: downloadIfWeb,
     );
   }
@@ -651,6 +663,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
         other.object == object &&
         other.fileName == fileName &&
         other.folder == folder &&
+        other.subFolder == subFolder &&
         other.downloadIfWeb == downloadIfWeb;
   }
 
@@ -660,6 +673,7 @@ class SaveJsonToFileDirectoryProvider extends AutoDisposeFutureProvider<void> {
     hash = _SystemHash.combine(hash, object.hashCode);
     hash = _SystemHash.combine(hash, fileName.hashCode);
     hash = _SystemHash.combine(hash, folder.hashCode);
+    hash = _SystemHash.combine(hash, subFolder.hashCode);
     hash = _SystemHash.combine(hash, downloadIfWeb.hashCode);
 
     return _SystemHash.finish(hash);
@@ -675,6 +689,9 @@ mixin SaveJsonToFileDirectoryRef on AutoDisposeFutureProviderRef<void> {
 
   /// The parameter `folder` of this provider.
   String get folder;
+
+  /// The parameter `subFolder` of this provider.
+  String? get subFolder;
 
   /// The parameter `downloadIfWeb` of this provider.
   bool get downloadIfWeb;
@@ -692,12 +709,15 @@ class _SaveJsonToFileDirectoryProviderElement
   @override
   String get folder => (origin as SaveJsonToFileDirectoryProvider).folder;
   @override
+  String? get subFolder =>
+      (origin as SaveJsonToFileDirectoryProvider).subFolder;
+  @override
   bool get downloadIfWeb =>
       (origin as SaveJsonToFileDirectoryProvider).downloadIfWeb;
 }
 
 String _$exportJsonToFileDirectoryHash() =>
-    r'0ceb65c7c3b0c009b2aff28c5f2b5a95ab838ffb';
+    r'87eec3dc92ce76fdeab0ae702ef31a17c31578f4';
 
 /// A provider for saving [object] to [fileName].json to a file in the [folder]
 /// in the file drectory.
@@ -747,12 +767,14 @@ class ExportJsonToFileDirectoryFamily extends Family {
     required dynamic object,
     required String fileName,
     String? folder,
+    String? subFolder,
     bool downloadIfWeb = true,
   }) {
     return ExportJsonToFileDirectoryProvider(
       object: object,
       fileName: fileName,
       folder: folder,
+      subFolder: subFolder,
       downloadIfWeb: downloadIfWeb,
     );
   }
@@ -766,6 +788,7 @@ class ExportJsonToFileDirectoryFamily extends Family {
       object: provider.object,
       fileName: provider.fileName,
       folder: provider.folder,
+      subFolder: provider.subFolder,
       downloadIfWeb: provider.downloadIfWeb,
     );
   }
@@ -811,6 +834,7 @@ class ExportJsonToFileDirectoryProvider
     required dynamic object,
     required String fileName,
     String? folder,
+    String? subFolder,
     bool downloadIfWeb = true,
   }) : this._internal(
           (ref) => exportJsonToFileDirectory(
@@ -818,6 +842,7 @@ class ExportJsonToFileDirectoryProvider
             object: object,
             fileName: fileName,
             folder: folder,
+            subFolder: subFolder,
             downloadIfWeb: downloadIfWeb,
           ),
           from: exportJsonToFileDirectoryProvider,
@@ -832,6 +857,7 @@ class ExportJsonToFileDirectoryProvider
           object: object,
           fileName: fileName,
           folder: folder,
+          subFolder: subFolder,
           downloadIfWeb: downloadIfWeb,
         );
 
@@ -845,12 +871,14 @@ class ExportJsonToFileDirectoryProvider
     required this.object,
     required this.fileName,
     required this.folder,
+    required this.subFolder,
     required this.downloadIfWeb,
   }) : super.internal();
 
   final dynamic object;
   final String fileName;
   final String? folder;
+  final String? subFolder;
   final bool downloadIfWeb;
 
   @override
@@ -869,6 +897,7 @@ class ExportJsonToFileDirectoryProvider
         object: object,
         fileName: fileName,
         folder: folder,
+        subFolder: subFolder,
         downloadIfWeb: downloadIfWeb,
       ),
     );
@@ -879,12 +908,14 @@ class ExportJsonToFileDirectoryProvider
     dynamic object,
     String fileName,
     String? folder,
+    String? subFolder,
     bool downloadIfWeb,
   }) get argument {
     return (
       object: object,
       fileName: fileName,
       folder: folder,
+      subFolder: subFolder,
       downloadIfWeb: downloadIfWeb,
     );
   }
@@ -907,6 +938,7 @@ class ExportJsonToFileDirectoryProvider
       object: object,
       fileName: fileName,
       folder: folder,
+      subFolder: subFolder,
       downloadIfWeb: downloadIfWeb,
     );
   }
@@ -917,6 +949,7 @@ class ExportJsonToFileDirectoryProvider
         other.object == object &&
         other.fileName == fileName &&
         other.folder == folder &&
+        other.subFolder == subFolder &&
         other.downloadIfWeb == downloadIfWeb;
   }
 
@@ -926,6 +959,7 @@ class ExportJsonToFileDirectoryProvider
     hash = _SystemHash.combine(hash, object.hashCode);
     hash = _SystemHash.combine(hash, fileName.hashCode);
     hash = _SystemHash.combine(hash, folder.hashCode);
+    hash = _SystemHash.combine(hash, subFolder.hashCode);
     hash = _SystemHash.combine(hash, downloadIfWeb.hashCode);
 
     return _SystemHash.finish(hash);
@@ -941,6 +975,9 @@ mixin ExportJsonToFileDirectoryRef on AutoDisposeFutureProviderRef<void> {
 
   /// The parameter `folder` of this provider.
   String? get folder;
+
+  /// The parameter `subFolder` of this provider.
+  String? get subFolder;
 
   /// The parameter `downloadIfWeb` of this provider.
   bool get downloadIfWeb;
@@ -958,11 +995,14 @@ class _ExportJsonToFileDirectoryProviderElement
   @override
   String? get folder => (origin as ExportJsonToFileDirectoryProvider).folder;
   @override
+  String? get subFolder =>
+      (origin as ExportJsonToFileDirectoryProvider).subFolder;
+  @override
   bool get downloadIfWeb =>
       (origin as ExportJsonToFileDirectoryProvider).downloadIfWeb;
 }
 
-String _$savedFilesHash() => r'778875525d9d2aa1e377bd52cbbd1278f91b702a';
+String _$savedFilesHash() => r'54d5b11822d84068f845c5895ba0a8c59d82cfd1';
 
 /// A provider for reading and holding all the saved objects of
 /// the given type in the in the user file directory.
@@ -1003,10 +1043,14 @@ class SavedFilesFamily extends Family {
   SavedFilesProvider call({
     required dynamic Function(Map<String, dynamic> json) fromJson,
     required String folder,
+    bool rebuildOnFileModification = true,
+    bool elementsInSubFolders = false,
   }) {
     return SavedFilesProvider(
       fromJson: fromJson,
       folder: folder,
+      rebuildOnFileModification: rebuildOnFileModification,
+      elementsInSubFolders: elementsInSubFolders,
     );
   }
 
@@ -1018,6 +1062,8 @@ class SavedFilesFamily extends Family {
     return call(
       fromJson: provider.fromJson,
       folder: provider.folder,
+      rebuildOnFileModification: provider.rebuildOnFileModification,
+      elementsInSubFolders: provider.elementsInSubFolders,
     );
   }
 
@@ -1056,11 +1102,15 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
   SavedFilesProvider({
     required dynamic Function(Map<String, dynamic> json) fromJson,
     required String folder,
+    bool rebuildOnFileModification = true,
+    bool elementsInSubFolders = false,
   }) : this._internal(
           (ref) => savedFiles(
             ref as SavedFilesRef,
             fromJson: fromJson,
             folder: folder,
+            rebuildOnFileModification: rebuildOnFileModification,
+            elementsInSubFolders: elementsInSubFolders,
           ),
           from: savedFilesProvider,
           name: r'savedFilesProvider',
@@ -1073,6 +1123,8 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
               SavedFilesFamily._allTransitiveDependencies,
           fromJson: fromJson,
           folder: folder,
+          rebuildOnFileModification: rebuildOnFileModification,
+          elementsInSubFolders: elementsInSubFolders,
         );
 
   SavedFilesProvider._internal(
@@ -1084,10 +1136,14 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
     required super.from,
     required this.fromJson,
     required this.folder,
+    required this.rebuildOnFileModification,
+    required this.elementsInSubFolders,
   }) : super.internal();
 
   final dynamic Function(Map<String, dynamic> json) fromJson;
   final String folder;
+  final bool rebuildOnFileModification;
+  final bool elementsInSubFolders;
 
   @override
   Override overrideWith(
@@ -1104,6 +1160,8 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
         debugGetCreateSourceHash: null,
         fromJson: fromJson,
         folder: folder,
+        rebuildOnFileModification: rebuildOnFileModification,
+        elementsInSubFolders: elementsInSubFolders,
       ),
     );
   }
@@ -1112,10 +1170,14 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
   ({
     dynamic Function(Map<String, dynamic> json) fromJson,
     String folder,
+    bool rebuildOnFileModification,
+    bool elementsInSubFolders,
   }) get argument {
     return (
       fromJson: fromJson,
       folder: folder,
+      rebuildOnFileModification: rebuildOnFileModification,
+      elementsInSubFolders: elementsInSubFolders,
     );
   }
 
@@ -1136,6 +1198,8 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
       from: from,
       fromJson: fromJson,
       folder: folder,
+      rebuildOnFileModification: rebuildOnFileModification,
+      elementsInSubFolders: elementsInSubFolders,
     );
   }
 
@@ -1143,7 +1207,9 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
   bool operator ==(Object other) {
     return other is SavedFilesProvider &&
         other.fromJson == fromJson &&
-        other.folder == folder;
+        other.folder == folder &&
+        other.rebuildOnFileModification == rebuildOnFileModification &&
+        other.elementsInSubFolders == elementsInSubFolders;
   }
 
   @override
@@ -1151,6 +1217,8 @@ class SavedFilesProvider extends FutureProvider<List<dynamic>> {
     var hash = _SystemHash.combine(0, runtimeType.hashCode);
     hash = _SystemHash.combine(hash, fromJson.hashCode);
     hash = _SystemHash.combine(hash, folder.hashCode);
+    hash = _SystemHash.combine(hash, rebuildOnFileModification.hashCode);
+    hash = _SystemHash.combine(hash, elementsInSubFolders.hashCode);
 
     return _SystemHash.finish(hash);
   }
@@ -1162,6 +1230,12 @@ mixin SavedFilesRef on FutureProviderRef<List<dynamic>> {
 
   /// The parameter `folder` of this provider.
   String get folder;
+
+  /// The parameter `rebuildOnFileModification` of this provider.
+  bool get rebuildOnFileModification;
+
+  /// The parameter `elementsInSubFolders` of this provider.
+  bool get elementsInSubFolders;
 }
 
 class _SavedFilesProviderElement extends FutureProviderElement<List<dynamic>>
@@ -1173,10 +1247,254 @@ class _SavedFilesProviderElement extends FutureProviderElement<List<dynamic>>
       (origin as SavedFilesProvider).fromJson;
   @override
   String get folder => (origin as SavedFilesProvider).folder;
+  @override
+  bool get rebuildOnFileModification =>
+      (origin as SavedFilesProvider).rebuildOnFileModification;
+  @override
+  bool get elementsInSubFolders =>
+      (origin as SavedFilesProvider).elementsInSubFolders;
+}
+
+String _$savedFilesInSubDirectoriesHash() =>
+    r'14160093fe72b8a4c90f450f01154789f8743b73';
+
+/// A provider for reading and holding all the saved objects of
+/// the given type in the in the user file directory.
+///
+/// Copied from [savedFilesInSubDirectories].
+@ProviderFor(savedFilesInSubDirectories)
+const savedFilesInSubDirectoriesProvider = SavedFilesInSubDirectoriesFamily();
+
+/// A provider for reading and holding all the saved objects of
+/// the given type in the in the user file directory.
+///
+/// Copied from [savedFilesInSubDirectories].
+class SavedFilesInSubDirectoriesFamily extends Family {
+  /// A provider for reading and holding all the saved objects of
+  /// the given type in the in the user file directory.
+  ///
+  /// Copied from [savedFilesInSubDirectories].
+  const SavedFilesInSubDirectoriesFamily();
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'savedFilesInSubDirectoriesProvider';
+
+  /// A provider for reading and holding all the saved objects of
+  /// the given type in the in the user file directory.
+  ///
+  /// Copied from [savedFilesInSubDirectories].
+  SavedFilesInSubDirectoriesProvider call({
+    required dynamic Function(Map<String, dynamic> json) fromJson,
+    required String folder,
+    bool rebuildOnFileModification = true,
+  }) {
+    return SavedFilesInSubDirectoriesProvider(
+      fromJson: fromJson,
+      folder: folder,
+      rebuildOnFileModification: rebuildOnFileModification,
+    );
+  }
+
+  @visibleForOverriding
+  @override
+  SavedFilesInSubDirectoriesProvider getProviderOverride(
+    covariant SavedFilesInSubDirectoriesProvider provider,
+  ) {
+    return call(
+      fromJson: provider.fromJson,
+      folder: provider.folder,
+      rebuildOnFileModification: provider.rebuildOnFileModification,
+    );
+  }
+
+  /// Enables overriding the behavior of this provider, no matter the parameters.
+  Override overrideWith(
+      FutureOr<List<dynamic>> Function(SavedFilesInSubDirectoriesRef ref)
+          create) {
+    return _$SavedFilesInSubDirectoriesFamilyOverride(this, create);
+  }
+}
+
+class _$SavedFilesInSubDirectoriesFamilyOverride implements FamilyOverride {
+  _$SavedFilesInSubDirectoriesFamilyOverride(
+      this.overriddenFamily, this.create);
+
+  final FutureOr<List<dynamic>> Function(SavedFilesInSubDirectoriesRef ref)
+      create;
+
+  @override
+  final SavedFilesInSubDirectoriesFamily overriddenFamily;
+
+  @override
+  SavedFilesInSubDirectoriesProvider getProviderOverride(
+    covariant SavedFilesInSubDirectoriesProvider provider,
+  ) {
+    return provider._copyWith(create);
+  }
+}
+
+/// A provider for reading and holding all the saved objects of
+/// the given type in the in the user file directory.
+///
+/// Copied from [savedFilesInSubDirectories].
+class SavedFilesInSubDirectoriesProvider extends FutureProvider<List<dynamic>> {
+  /// A provider for reading and holding all the saved objects of
+  /// the given type in the in the user file directory.
+  ///
+  /// Copied from [savedFilesInSubDirectories].
+  SavedFilesInSubDirectoriesProvider({
+    required dynamic Function(Map<String, dynamic> json) fromJson,
+    required String folder,
+    bool rebuildOnFileModification = true,
+  }) : this._internal(
+          (ref) => savedFilesInSubDirectories(
+            ref as SavedFilesInSubDirectoriesRef,
+            fromJson: fromJson,
+            folder: folder,
+            rebuildOnFileModification: rebuildOnFileModification,
+          ),
+          from: savedFilesInSubDirectoriesProvider,
+          name: r'savedFilesInSubDirectoriesProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$savedFilesInSubDirectoriesHash,
+          dependencies: SavedFilesInSubDirectoriesFamily._dependencies,
+          allTransitiveDependencies:
+              SavedFilesInSubDirectoriesFamily._allTransitiveDependencies,
+          fromJson: fromJson,
+          folder: folder,
+          rebuildOnFileModification: rebuildOnFileModification,
+        );
+
+  SavedFilesInSubDirectoriesProvider._internal(
+    super.create, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.fromJson,
+    required this.folder,
+    required this.rebuildOnFileModification,
+  }) : super.internal();
+
+  final dynamic Function(Map<String, dynamic> json) fromJson;
+  final String folder;
+  final bool rebuildOnFileModification;
+
+  @override
+  Override overrideWith(
+    FutureOr<List<dynamic>> Function(SavedFilesInSubDirectoriesRef ref) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: SavedFilesInSubDirectoriesProvider._internal(
+        (ref) => create(ref as SavedFilesInSubDirectoriesRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        fromJson: fromJson,
+        folder: folder,
+        rebuildOnFileModification: rebuildOnFileModification,
+      ),
+    );
+  }
+
+  @override
+  ({
+    dynamic Function(Map<String, dynamic> json) fromJson,
+    String folder,
+    bool rebuildOnFileModification,
+  }) get argument {
+    return (
+      fromJson: fromJson,
+      folder: folder,
+      rebuildOnFileModification: rebuildOnFileModification,
+    );
+  }
+
+  @override
+  FutureProviderElement<List<dynamic>> createElement() {
+    return _SavedFilesInSubDirectoriesProviderElement(this);
+  }
+
+  SavedFilesInSubDirectoriesProvider _copyWith(
+    FutureOr<List<dynamic>> Function(SavedFilesInSubDirectoriesRef ref) create,
+  ) {
+    return SavedFilesInSubDirectoriesProvider._internal(
+      (ref) => create(ref as SavedFilesInSubDirectoriesRef),
+      name: name,
+      dependencies: dependencies,
+      allTransitiveDependencies: allTransitiveDependencies,
+      debugGetCreateSourceHash: debugGetCreateSourceHash,
+      from: from,
+      fromJson: fromJson,
+      folder: folder,
+      rebuildOnFileModification: rebuildOnFileModification,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SavedFilesInSubDirectoriesProvider &&
+        other.fromJson == fromJson &&
+        other.folder == folder &&
+        other.rebuildOnFileModification == rebuildOnFileModification;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, fromJson.hashCode);
+    hash = _SystemHash.combine(hash, folder.hashCode);
+    hash = _SystemHash.combine(hash, rebuildOnFileModification.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin SavedFilesInSubDirectoriesRef on FutureProviderRef<List<dynamic>> {
+  /// The parameter `fromJson` of this provider.
+  dynamic Function(Map<String, dynamic> json) get fromJson;
+
+  /// The parameter `folder` of this provider.
+  String get folder;
+
+  /// The parameter `rebuildOnFileModification` of this provider.
+  bool get rebuildOnFileModification;
+}
+
+class _SavedFilesInSubDirectoriesProviderElement
+    extends FutureProviderElement<List<dynamic>>
+    with SavedFilesInSubDirectoriesRef {
+  _SavedFilesInSubDirectoriesProviderElement(super.provider);
+
+  @override
+  dynamic Function(Map<String, dynamic> json) get fromJson =>
+      (origin as SavedFilesInSubDirectoriesProvider).fromJson;
+  @override
+  String get folder => (origin as SavedFilesInSubDirectoriesProvider).folder;
+  @override
+  bool get rebuildOnFileModification =>
+      (origin as SavedFilesInSubDirectoriesProvider).rebuildOnFileModification;
 }
 
 String _$deleteJsonFromFileDirectoryHash() =>
-    r'546b298f9d5a0d5b63918fa3cfeacd797a46a922';
+    r'232132d19d72be35fafdf8448f51a80d80cdac8d';
 
 /// A provider for deleting the [fileName] in [folder] if it exists.
 ///
@@ -1386,8 +1704,223 @@ class _DeleteJsonFromFileDirectoryProviderElement
   String get folder => (origin as DeleteJsonFromFileDirectoryProvider).folder;
 }
 
+String _$deleteDirectoryFromFileDirectoryHash() =>
+    r'1d899567355ef22cd0559c86a0497fe8fba8448f';
+
+/// A provider for deleting the [directoryName] in [folder] if it exists.
+///
+/// Copied from [deleteDirectoryFromFileDirectory].
+@ProviderFor(deleteDirectoryFromFileDirectory)
+const deleteDirectoryFromFileDirectoryProvider =
+    DeleteDirectoryFromFileDirectoryFamily();
+
+/// A provider for deleting the [directoryName] in [folder] if it exists.
+///
+/// Copied from [deleteDirectoryFromFileDirectory].
+class DeleteDirectoryFromFileDirectoryFamily extends Family {
+  /// A provider for deleting the [directoryName] in [folder] if it exists.
+  ///
+  /// Copied from [deleteDirectoryFromFileDirectory].
+  const DeleteDirectoryFromFileDirectoryFamily();
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'deleteDirectoryFromFileDirectoryProvider';
+
+  /// A provider for deleting the [directoryName] in [folder] if it exists.
+  ///
+  /// Copied from [deleteDirectoryFromFileDirectory].
+  DeleteDirectoryFromFileDirectoryProvider call({
+    required String directoryName,
+    required String folder,
+  }) {
+    return DeleteDirectoryFromFileDirectoryProvider(
+      directoryName: directoryName,
+      folder: folder,
+    );
+  }
+
+  @visibleForOverriding
+  @override
+  DeleteDirectoryFromFileDirectoryProvider getProviderOverride(
+    covariant DeleteDirectoryFromFileDirectoryProvider provider,
+  ) {
+    return call(
+      directoryName: provider.directoryName,
+      folder: provider.folder,
+    );
+  }
+
+  /// Enables overriding the behavior of this provider, no matter the parameters.
+  Override overrideWith(
+      FutureOr<void> Function(DeleteDirectoryFromFileDirectoryRef ref) create) {
+    return _$DeleteDirectoryFromFileDirectoryFamilyOverride(this, create);
+  }
+}
+
+class _$DeleteDirectoryFromFileDirectoryFamilyOverride
+    implements FamilyOverride {
+  _$DeleteDirectoryFromFileDirectoryFamilyOverride(
+      this.overriddenFamily, this.create);
+
+  final FutureOr<void> Function(DeleteDirectoryFromFileDirectoryRef ref) create;
+
+  @override
+  final DeleteDirectoryFromFileDirectoryFamily overriddenFamily;
+
+  @override
+  DeleteDirectoryFromFileDirectoryProvider getProviderOverride(
+    covariant DeleteDirectoryFromFileDirectoryProvider provider,
+  ) {
+    return provider._copyWith(create);
+  }
+}
+
+/// A provider for deleting the [directoryName] in [folder] if it exists.
+///
+/// Copied from [deleteDirectoryFromFileDirectory].
+class DeleteDirectoryFromFileDirectoryProvider
+    extends AutoDisposeFutureProvider<void> {
+  /// A provider for deleting the [directoryName] in [folder] if it exists.
+  ///
+  /// Copied from [deleteDirectoryFromFileDirectory].
+  DeleteDirectoryFromFileDirectoryProvider({
+    required String directoryName,
+    required String folder,
+  }) : this._internal(
+          (ref) => deleteDirectoryFromFileDirectory(
+            ref as DeleteDirectoryFromFileDirectoryRef,
+            directoryName: directoryName,
+            folder: folder,
+          ),
+          from: deleteDirectoryFromFileDirectoryProvider,
+          name: r'deleteDirectoryFromFileDirectoryProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$deleteDirectoryFromFileDirectoryHash,
+          dependencies: DeleteDirectoryFromFileDirectoryFamily._dependencies,
+          allTransitiveDependencies:
+              DeleteDirectoryFromFileDirectoryFamily._allTransitiveDependencies,
+          directoryName: directoryName,
+          folder: folder,
+        );
+
+  DeleteDirectoryFromFileDirectoryProvider._internal(
+    super.create, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.directoryName,
+    required this.folder,
+  }) : super.internal();
+
+  final String directoryName;
+  final String folder;
+
+  @override
+  Override overrideWith(
+    FutureOr<void> Function(DeleteDirectoryFromFileDirectoryRef ref) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: DeleteDirectoryFromFileDirectoryProvider._internal(
+        (ref) => create(ref as DeleteDirectoryFromFileDirectoryRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        directoryName: directoryName,
+        folder: folder,
+      ),
+    );
+  }
+
+  @override
+  ({
+    String directoryName,
+    String folder,
+  }) get argument {
+    return (
+      directoryName: directoryName,
+      folder: folder,
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<void> createElement() {
+    return _DeleteDirectoryFromFileDirectoryProviderElement(this);
+  }
+
+  DeleteDirectoryFromFileDirectoryProvider _copyWith(
+    FutureOr<void> Function(DeleteDirectoryFromFileDirectoryRef ref) create,
+  ) {
+    return DeleteDirectoryFromFileDirectoryProvider._internal(
+      (ref) => create(ref as DeleteDirectoryFromFileDirectoryRef),
+      name: name,
+      dependencies: dependencies,
+      allTransitiveDependencies: allTransitiveDependencies,
+      debugGetCreateSourceHash: debugGetCreateSourceHash,
+      from: from,
+      directoryName: directoryName,
+      folder: folder,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is DeleteDirectoryFromFileDirectoryProvider &&
+        other.directoryName == directoryName &&
+        other.folder == folder;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, directoryName.hashCode);
+    hash = _SystemHash.combine(hash, folder.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin DeleteDirectoryFromFileDirectoryRef
+    on AutoDisposeFutureProviderRef<void> {
+  /// The parameter `directoryName` of this provider.
+  String get directoryName;
+
+  /// The parameter `folder` of this provider.
+  String get folder;
+}
+
+class _DeleteDirectoryFromFileDirectoryProviderElement
+    extends AutoDisposeFutureProviderElement<void>
+    with DeleteDirectoryFromFileDirectoryRef {
+  _DeleteDirectoryFromFileDirectoryProviderElement(super.provider);
+
+  @override
+  String get directoryName =>
+      (origin as DeleteDirectoryFromFileDirectoryProvider).directoryName;
+  @override
+  String get folder =>
+      (origin as DeleteDirectoryFromFileDirectoryProvider).folder;
+}
+
 String _$exportWholeFileDirectoryHash() =>
-    r'ca1c16db3da10d6c0c425ff869956d56a9495213';
+    r'a2b987f5d594154c8f308b95ad8f3c78f5f2af3f';
 
 /// A provider for exporting the whole file directory to a ZIP file.
 ///
@@ -1405,7 +1938,7 @@ final exportWholeFileDirectoryProvider =
 );
 
 typedef ExportWholeFileDirectoryRef = AutoDisposeFutureProviderRef<void>;
-String _$exportAllHash() => r'f16b3702330a37f98cbe906530afc7d75af85af5';
+String _$exportAllHash() => r'8be8c125bd85c4728942cd2feb4b43ad3f2fc3b8';
 
 /// A provider for exporting all files in a [directory].
 ///

--- a/lib/src/features/common/providers/logging_providers.dart
+++ b/lib/src/features/common/providers/logging_providers.dart
@@ -75,7 +75,7 @@ Future<File?> loggingFile(LoggingFileRef ref) async {
       microsecond: 0,
     );
 
-    final logsDir = Directory([dirPath, 'logs'].join('/'));
+    final logsDir = Directory([dirPath, 'logs'].join(Platform.pathSeparator));
     if (logsDir.existsSync()) {
       final files = logsDir
           .listSync()
@@ -112,7 +112,9 @@ Future<File?> loggingFile(LoggingFileRef ref) async {
 
     for (final hardware in ['combined', 'imu', 'gnss', 'was']) {
       final hardwareLogsDir =
-          Directory([dirPath, 'logs', 'hardware', hardware].join('/'));
+          Directory(
+        [dirPath, 'logs', 'hardware', hardware].join(Platform.pathSeparator),
+      );
       if (hardwareLogsDir.existsSync()) {
         final files = hardwareLogsDir
             .listSync()
@@ -152,7 +154,7 @@ Future<File?> loggingFile(LoggingFileRef ref) async {
       dirPath,
       'logs',
       '${Logger.instance.initializeTime.toIso8601String()}.log',
-    ].join('/');
+    ].join(Platform.pathSeparator);
 
     final file = await File(path).create(recursive: true);
 

--- a/lib/src/features/common/providers/logging_providers.g.dart
+++ b/lib/src/features/common/providers/logging_providers.g.dart
@@ -6,7 +6,7 @@ part of 'logging_providers.dart';
 // RiverpodGenerator
 // **************************************************************************
 
-String _$loggingFileHash() => r'f87dfce64626880f837b9e8322b605260c647986';
+String _$loggingFileHash() => r'6a8fddc7f2fa51853389e25c769df2133e637232';
 
 /// A provider for creating a logging file for the session.
 ///

--- a/lib/src/features/common/utils/date_time_serializer.dart
+++ b/lib/src/features/common/utils/date_time_serializer.dart
@@ -18,12 +18,12 @@
 import 'package:json_annotation/json_annotation.dart';
 
 /// A JSON serializer for [DateTime] to simplify the usage in freezed models.
-class DateTimeSerializer implements JsonConverter<DateTime?, String> {
+class DateTimeSerializer implements JsonConverter<DateTime, String> {
   /// A JSON serializer for [DateTime] to simplify the usage in freezed models.
   const DateTimeSerializer();
   @override
-  DateTime? fromJson(String json) => DateTime.tryParse(json);
+  DateTime fromJson(String json) => DateTime.parse(json);
 
   @override
-  String toJson(DateTime? object) => object?.toIso8601String() ?? 'No time';
+  String toJson(DateTime object) => object.toIso8601String();
 }

--- a/lib/src/features/common/utils/sub_directory_finder_extension.dart
+++ b/lib/src/features/common/utils/sub_directory_finder_extension.dart
@@ -36,7 +36,7 @@ extension SubDirectoryFinder on Directory {
     final contents = listSync();
 
     for (final element in contents) {
-      if (element.path == ([path, 'created'].join('/'))) {
+      if (element.path == ([path, 'created'].join(Platform.pathSeparator))) {
         result.add(path);
       } else if (element.statSync().type == FileSystemEntityType.directory) {
         result.addAll(

--- a/lib/src/features/equipment/models/equipment_log_record.dart
+++ b/lib/src/features/equipment/models/equipment_log_record.dart
@@ -1,0 +1,45 @@
+// Copyright (C) 2024 Gaute Hagen
+//
+// This file is part of Autosteering.
+//
+// Autosteering is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// Autosteering is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+//
+// You should have received a copy of the GNU General Public License
+// along with Autosteering.  If not, see <https://www.gnu.org/licenses/>.
+
+import 'package:autosteering/src/features/common/common.dart';
+import 'package:autosteering/src/features/guidance/guidance.dart';
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'equipment_log_record.freezed.dart';
+part 'equipment_log_record.g.dart';
+
+/// A log record for logging the equipment's position  and active state at the
+/// given time.
+@freezed
+class EquipmentLogRecord with _$EquipmentLogRecord {
+  /// A log record for logging the equipment's position [wayPoint] and active
+  /// state [activeSections] at the given [time] stamp.
+  const factory EquipmentLogRecord({
+    /// Time stamp of this.
+    @DateTimeSerializer() required DateTime time,
+
+    /// List of the section indices for the active sections only.
+    required List<int> activeSections,
+
+    /// [WayPoint] for position and bearing of the equipment.
+    required WayPoint wayPoint,
+  }) = _EquipmentLogRecord;
+
+  /// Creates an [EquipmentLogRecord] from the [json] object.
+  factory EquipmentLogRecord.fromJson(Map<String, Object?> json) =>
+      _$EquipmentLogRecordFromJson(json);
+}

--- a/lib/src/features/equipment/models/equipment_log_record.freezed.dart
+++ b/lib/src/features/equipment/models/equipment_log_record.freezed.dart
@@ -1,0 +1,226 @@
+// coverage:ignore-file
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: type=lint
+// ignore_for_file: unused_element, deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies, annotate_overrides, invalid_annotation_target, unnecessary_question_mark
+
+part of 'equipment_log_record.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+final _privateConstructorUsedError = UnsupportedError(
+    'It seems like you constructed your class using `MyClass._()`. This constructor is only meant to be used by freezed and you are not supposed to need it nor use it.\nPlease check the documentation here for more information: https://github.com/rrousselGit/freezed#adding-getters-and-methods-to-our-models');
+
+EquipmentLogRecord _$EquipmentLogRecordFromJson(Map<String, dynamic> json) {
+  return _EquipmentLogRecord.fromJson(json);
+}
+
+/// @nodoc
+mixin _$EquipmentLogRecord {
+  /// Time stamp of this.
+  @DateTimeSerializer()
+  DateTime get time => throw _privateConstructorUsedError;
+
+  /// List of the section indices for the active sections only.
+  List<int> get activeSections => throw _privateConstructorUsedError;
+
+  /// [WayPoint] for position and bearing of the equipment.
+  WayPoint get wayPoint => throw _privateConstructorUsedError;
+
+  Map<String, dynamic> toJson() => throw _privateConstructorUsedError;
+  @JsonKey(ignore: true)
+  $EquipmentLogRecordCopyWith<EquipmentLogRecord> get copyWith =>
+      throw _privateConstructorUsedError;
+}
+
+/// @nodoc
+abstract class $EquipmentLogRecordCopyWith<$Res> {
+  factory $EquipmentLogRecordCopyWith(
+          EquipmentLogRecord value, $Res Function(EquipmentLogRecord) then) =
+      _$EquipmentLogRecordCopyWithImpl<$Res, EquipmentLogRecord>;
+  @useResult
+  $Res call(
+      {@DateTimeSerializer() DateTime time,
+      List<int> activeSections,
+      WayPoint wayPoint});
+}
+
+/// @nodoc
+class _$EquipmentLogRecordCopyWithImpl<$Res, $Val extends EquipmentLogRecord>
+    implements $EquipmentLogRecordCopyWith<$Res> {
+  _$EquipmentLogRecordCopyWithImpl(this._value, this._then);
+
+  // ignore: unused_field
+  final $Val _value;
+  // ignore: unused_field
+  final $Res Function($Val) _then;
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? time = null,
+    Object? activeSections = null,
+    Object? wayPoint = null,
+  }) {
+    return _then(_value.copyWith(
+      time: null == time
+          ? _value.time
+          : time // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      activeSections: null == activeSections
+          ? _value.activeSections
+          : activeSections // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+      wayPoint: null == wayPoint
+          ? _value.wayPoint
+          : wayPoint // ignore: cast_nullable_to_non_nullable
+              as WayPoint,
+    ) as $Val);
+  }
+}
+
+/// @nodoc
+abstract class _$$EquipmentLogRecordImplCopyWith<$Res>
+    implements $EquipmentLogRecordCopyWith<$Res> {
+  factory _$$EquipmentLogRecordImplCopyWith(_$EquipmentLogRecordImpl value,
+          $Res Function(_$EquipmentLogRecordImpl) then) =
+      __$$EquipmentLogRecordImplCopyWithImpl<$Res>;
+  @override
+  @useResult
+  $Res call(
+      {@DateTimeSerializer() DateTime time,
+      List<int> activeSections,
+      WayPoint wayPoint});
+}
+
+/// @nodoc
+class __$$EquipmentLogRecordImplCopyWithImpl<$Res>
+    extends _$EquipmentLogRecordCopyWithImpl<$Res, _$EquipmentLogRecordImpl>
+    implements _$$EquipmentLogRecordImplCopyWith<$Res> {
+  __$$EquipmentLogRecordImplCopyWithImpl(_$EquipmentLogRecordImpl _value,
+      $Res Function(_$EquipmentLogRecordImpl) _then)
+      : super(_value, _then);
+
+  @pragma('vm:prefer-inline')
+  @override
+  $Res call({
+    Object? time = null,
+    Object? activeSections = null,
+    Object? wayPoint = null,
+  }) {
+    return _then(_$EquipmentLogRecordImpl(
+      time: null == time
+          ? _value.time
+          : time // ignore: cast_nullable_to_non_nullable
+              as DateTime,
+      activeSections: null == activeSections
+          ? _value._activeSections
+          : activeSections // ignore: cast_nullable_to_non_nullable
+              as List<int>,
+      wayPoint: null == wayPoint
+          ? _value.wayPoint
+          : wayPoint // ignore: cast_nullable_to_non_nullable
+              as WayPoint,
+    ));
+  }
+}
+
+/// @nodoc
+@JsonSerializable()
+class _$EquipmentLogRecordImpl implements _EquipmentLogRecord {
+  const _$EquipmentLogRecordImpl(
+      {@DateTimeSerializer() required this.time,
+      required final List<int> activeSections,
+      required this.wayPoint})
+      : _activeSections = activeSections;
+
+  factory _$EquipmentLogRecordImpl.fromJson(Map<String, dynamic> json) =>
+      _$$EquipmentLogRecordImplFromJson(json);
+
+  /// Time stamp of this.
+  @override
+  @DateTimeSerializer()
+  final DateTime time;
+
+  /// List of the section indices for the active sections only.
+  final List<int> _activeSections;
+
+  /// List of the section indices for the active sections only.
+  @override
+  List<int> get activeSections {
+    if (_activeSections is EqualUnmodifiableListView) return _activeSections;
+    // ignore: implicit_dynamic_type
+    return EqualUnmodifiableListView(_activeSections);
+  }
+
+  /// [WayPoint] for position and bearing of the equipment.
+  @override
+  final WayPoint wayPoint;
+
+  @override
+  String toString() {
+    return 'EquipmentLogRecord(time: $time, activeSections: $activeSections, wayPoint: $wayPoint)';
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return identical(this, other) ||
+        (other.runtimeType == runtimeType &&
+            other is _$EquipmentLogRecordImpl &&
+            (identical(other.time, time) || other.time == time) &&
+            const DeepCollectionEquality()
+                .equals(other._activeSections, _activeSections) &&
+            (identical(other.wayPoint, wayPoint) ||
+                other.wayPoint == wayPoint));
+  }
+
+  @JsonKey(ignore: true)
+  @override
+  int get hashCode => Object.hash(runtimeType, time,
+      const DeepCollectionEquality().hash(_activeSections), wayPoint);
+
+  @JsonKey(ignore: true)
+  @override
+  @pragma('vm:prefer-inline')
+  _$$EquipmentLogRecordImplCopyWith<_$EquipmentLogRecordImpl> get copyWith =>
+      __$$EquipmentLogRecordImplCopyWithImpl<_$EquipmentLogRecordImpl>(
+          this, _$identity);
+
+  @override
+  Map<String, dynamic> toJson() {
+    return _$$EquipmentLogRecordImplToJson(
+      this,
+    );
+  }
+}
+
+abstract class _EquipmentLogRecord implements EquipmentLogRecord {
+  const factory _EquipmentLogRecord(
+      {@DateTimeSerializer() required final DateTime time,
+      required final List<int> activeSections,
+      required final WayPoint wayPoint}) = _$EquipmentLogRecordImpl;
+
+  factory _EquipmentLogRecord.fromJson(Map<String, dynamic> json) =
+      _$EquipmentLogRecordImpl.fromJson;
+
+  @override
+
+  /// Time stamp of this.
+  @DateTimeSerializer()
+  DateTime get time;
+  @override
+
+  /// List of the section indices for the active sections only.
+  List<int> get activeSections;
+  @override
+
+  /// [WayPoint] for position and bearing of the equipment.
+  WayPoint get wayPoint;
+  @override
+  @JsonKey(ignore: true)
+  _$$EquipmentLogRecordImplCopyWith<_$EquipmentLogRecordImpl> get copyWith =>
+      throw _privateConstructorUsedError;
+}

--- a/lib/src/features/equipment/models/equipment_log_record.g.dart
+++ b/lib/src/features/equipment/models/equipment_log_record.g.dart
@@ -1,0 +1,25 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'equipment_log_record.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+_$EquipmentLogRecordImpl _$$EquipmentLogRecordImplFromJson(
+        Map<String, dynamic> json) =>
+    _$EquipmentLogRecordImpl(
+      time: const DateTimeSerializer().fromJson(json['time'] as String),
+      activeSections: (json['activeSections'] as List<dynamic>)
+          .map((e) => (e as num).toInt())
+          .toList(),
+      wayPoint: WayPoint.fromJson(json['wayPoint'] as Map<String, dynamic>),
+    );
+
+Map<String, dynamic> _$$EquipmentLogRecordImplToJson(
+        _$EquipmentLogRecordImpl instance) =>
+    <String, dynamic>{
+      'time': const DateTimeSerializer().toJson(instance.time),
+      'activeSections': instance.activeSections,
+      'wayPoint': instance.wayPoint,
+    };

--- a/lib/src/features/equipment/models/equipment_setup.dart
+++ b/lib/src/features/equipment/models/equipment_setup.dart
@@ -17,6 +17,7 @@
 
 import 'package:autosteering/src/features/equipment/equipment.dart';
 import 'package:autosteering/src/features/hitching/hitching.dart';
+import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 
 /// A class that contains a setup for attached [Equipment]s that
@@ -130,12 +131,38 @@ class EquipmentSetup with EquatableMixin {
   /// Lists all the children attached and their children recursively.
   List<Hitchable> get allAttached {
     final list = <Hitchable>[
-      if (frontFixedChild != null) frontFixedChild!,
-      if (rearFixedChild != null) rearFixedChild!,
-      if (rearTowbarChild != null) rearTowbarChild!,
+      if (frontFixedChild != null) ...[
+        frontFixedChild!,
+        ...frontFixedChild!.hitchChildren,
+      ],
+      if (rearFixedChild != null) ...[
+        rearFixedChild!,
+        ...rearFixedChild!.hitchChildren,
+      ],
+      if (rearTowbarChild != null) ...[
+        rearTowbarChild!,
+        ...rearTowbarChild!.hitchChildren,
+      ],
     ];
 
     return list;
+  }
+
+  /// Attempts to find the parent-child hitch relation of [child] in this,
+  /// otherwise returns null.
+  Hitch? findHitchOfChild(Hitchable child) {
+    if (child.uuid == frontFixedChild?.uuid) {
+      return Hitch.frontFixed;
+    }
+    if (child.uuid == rearFixedChild?.uuid) {
+      return Hitch.rearFixed;
+    }
+    if (child.uuid == rearTowbarChild?.uuid) {
+      return Hitch.rearTowbar;
+    }
+    final recursiveChild =
+        allAttached.firstWhereOrNull((element) => element.uuid == child.uuid);
+    return recursiveChild?.parentHitch;
   }
 
   /// Converts the object to a json compatible structure.

--- a/lib/src/features/equipment/models/models.dart
+++ b/lib/src/features/equipment/models/models.dart
@@ -16,5 +16,6 @@
 // along with Autosteering.  If not, see <https://www.gnu.org/licenses/>.
 
 export 'equipment.dart';
+export 'equipment_log_record.dart';
 export 'equipment_setup.dart';
 export 'section.dart';

--- a/lib/src/features/equipment/providers/equipment_providers.g.dart
+++ b/lib/src/features/equipment/providers/equipment_providers.g.dart
@@ -1198,7 +1198,7 @@ final equipmentWorkedAreaProvider =
 );
 
 typedef _$EquipmentWorkedArea = Notifier<Map<String, double>>;
-String _$equipmentPathsHash() => r'bd9aca4d0962648558dd5789257637c17dd97de5';
+String _$equipmentPathsHash() => r'f2f4b26a006664308c06218d51213fb23a310cad';
 
 abstract class _$EquipmentPaths
     extends BuildlessNotifier<List<Map<int, List<SectionEdgePositions>?>>> {
@@ -1394,6 +1394,210 @@ class _EquipmentPathsProviderElement extends NotifierProviderElement<
 
   @override
   String get uuid => (origin as EquipmentPathsProvider).uuid;
+}
+
+String _$equipmentLogRecordsHash() =>
+    r'58bb0faed8b3db7b1cced9e13998c0b74f1b5c4c';
+
+abstract class _$EquipmentLogRecords
+    extends BuildlessNotifier<List<EquipmentLogRecord>?> {
+  late final String uuid;
+
+  List<EquipmentLogRecord>? build(
+    String uuid,
+  );
+}
+
+/// A provider for holding [EquipmentLogRecord] for the [Equipment] with the
+/// given UUID.
+///
+/// Copied from [EquipmentLogRecords].
+@ProviderFor(EquipmentLogRecords)
+const equipmentLogRecordsProvider = EquipmentLogRecordsFamily();
+
+/// A provider for holding [EquipmentLogRecord] for the [Equipment] with the
+/// given UUID.
+///
+/// Copied from [EquipmentLogRecords].
+class EquipmentLogRecordsFamily extends Family {
+  /// A provider for holding [EquipmentLogRecord] for the [Equipment] with the
+  /// given UUID.
+  ///
+  /// Copied from [EquipmentLogRecords].
+  const EquipmentLogRecordsFamily();
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'equipmentLogRecordsProvider';
+
+  /// A provider for holding [EquipmentLogRecord] for the [Equipment] with the
+  /// given UUID.
+  ///
+  /// Copied from [EquipmentLogRecords].
+  EquipmentLogRecordsProvider call(
+    String uuid,
+  ) {
+    return EquipmentLogRecordsProvider(
+      uuid,
+    );
+  }
+
+  @visibleForOverriding
+  @override
+  EquipmentLogRecordsProvider getProviderOverride(
+    covariant EquipmentLogRecordsProvider provider,
+  ) {
+    return call(
+      provider.uuid,
+    );
+  }
+
+  /// Enables overriding the behavior of this provider, no matter the parameters.
+  Override overrideWith(EquipmentLogRecords Function() create) {
+    return _$EquipmentLogRecordsFamilyOverride(this, create);
+  }
+}
+
+class _$EquipmentLogRecordsFamilyOverride implements FamilyOverride {
+  _$EquipmentLogRecordsFamilyOverride(this.overriddenFamily, this.create);
+
+  final EquipmentLogRecords Function() create;
+
+  @override
+  final EquipmentLogRecordsFamily overriddenFamily;
+
+  @override
+  EquipmentLogRecordsProvider getProviderOverride(
+    covariant EquipmentLogRecordsProvider provider,
+  ) {
+    return provider._copyWith(create);
+  }
+}
+
+/// A provider for holding [EquipmentLogRecord] for the [Equipment] with the
+/// given UUID.
+///
+/// Copied from [EquipmentLogRecords].
+class EquipmentLogRecordsProvider extends NotifierProviderImpl<
+    EquipmentLogRecords, List<EquipmentLogRecord>?> {
+  /// A provider for holding [EquipmentLogRecord] for the [Equipment] with the
+  /// given UUID.
+  ///
+  /// Copied from [EquipmentLogRecords].
+  EquipmentLogRecordsProvider(
+    String uuid,
+  ) : this._internal(
+          () => EquipmentLogRecords()..uuid = uuid,
+          from: equipmentLogRecordsProvider,
+          name: r'equipmentLogRecordsProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$equipmentLogRecordsHash,
+          dependencies: EquipmentLogRecordsFamily._dependencies,
+          allTransitiveDependencies:
+              EquipmentLogRecordsFamily._allTransitiveDependencies,
+          uuid: uuid,
+        );
+
+  EquipmentLogRecordsProvider._internal(
+    super.create, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.uuid,
+  }) : super.internal();
+
+  final String uuid;
+
+  @override
+  List<EquipmentLogRecord>? runNotifierBuild(
+    covariant EquipmentLogRecords notifier,
+  ) {
+    return notifier.build(
+      uuid,
+    );
+  }
+
+  @override
+  Override overrideWith(EquipmentLogRecords Function() create) {
+    return ProviderOverride(
+      origin: this,
+      override: EquipmentLogRecordsProvider._internal(
+        () => create()..uuid = uuid,
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        uuid: uuid,
+      ),
+    );
+  }
+
+  @override
+  (String,) get argument {
+    return (uuid,);
+  }
+
+  @override
+  NotifierProviderElement<EquipmentLogRecords, List<EquipmentLogRecord>?>
+      createElement() {
+    return _EquipmentLogRecordsProviderElement(this);
+  }
+
+  EquipmentLogRecordsProvider _copyWith(
+    EquipmentLogRecords Function() create,
+  ) {
+    return EquipmentLogRecordsProvider._internal(
+      () => create()..uuid = uuid,
+      name: name,
+      dependencies: dependencies,
+      allTransitiveDependencies: allTransitiveDependencies,
+      debugGetCreateSourceHash: debugGetCreateSourceHash,
+      from: from,
+      uuid: uuid,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is EquipmentLogRecordsProvider && other.uuid == uuid;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, uuid.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin EquipmentLogRecordsRef on NotifierProviderRef<List<EquipmentLogRecord>?> {
+  /// The parameter `uuid` of this provider.
+  String get uuid;
+}
+
+class _EquipmentLogRecordsProviderElement extends NotifierProviderElement<
+    EquipmentLogRecords,
+    List<EquipmentLogRecord>?> with EquipmentLogRecordsRef {
+  _EquipmentLogRecordsProviderElement(super.provider);
+
+  @override
+  String get uuid => (origin as EquipmentLogRecordsProvider).uuid;
 }
 // ignore_for_file: type=lint
 // ignore_for_file: subtype_of_sealed_class, invalid_use_of_internal_member, invalid_use_of_visible_for_testing_member, inference_failure_on_uninitialized_variable, inference_failure_on_function_return_type, inference_failure_on_untyped_parameter, deprecated_member_use_from_same_package

--- a/lib/src/features/equipment/providers/equipment_setup_providers.dart
+++ b/lib/src/features/equipment/providers/equipment_setup_providers.dart
@@ -62,7 +62,7 @@ FutureOr<void> saveEquipmentSetup(
       saveJsonToFileDirectoryProvider(
         object: setup,
         fileName: overrideName ?? setup.name,
-        folder: 'equipment/setups',
+        folder: ['equipment', 'setups'].join(Platform.pathSeparator),
         downloadIfWeb: downloadIfWeb,
       ).future,
     );
@@ -81,7 +81,7 @@ FutureOr<void> exportEquipmentSetup(
       exportJsonToFileDirectoryProvider(
         object: setup,
         fileName: overrideName ?? setup.name,
-        folder: 'equipment/setups',
+        folder: ['equipment', 'setups'].join(Platform.pathSeparator),
         downloadIfWeb: downloadIfWeb,
       ).future,
     );
@@ -96,7 +96,7 @@ FutureOr<List<EquipmentSetup>> savedEquipmentSetups(
         .watch(
       savedFilesProvider(
         fromJson: EquipmentSetup.fromJson,
-        folder: 'equipment/setups',
+        folder: ['equipment', 'setups'].join(Platform.pathSeparator),
       ).future,
     )
         .then((data) {
@@ -118,7 +118,7 @@ FutureOr<void> deleteEquipmentSetup(
     await ref.watch(
       deleteJsonFromFileDirectoryProvider(
         fileName: overrideName ?? setup.name,
-        folder: 'equipment/setups',
+        folder: ['equipment', 'setups'].join(Platform.pathSeparator),
       ).future,
     );
 

--- a/lib/src/features/equipment/providers/equipment_setup_providers.g.dart
+++ b/lib/src/features/equipment/providers/equipment_setup_providers.g.dart
@@ -7,7 +7,7 @@ part of 'equipment_setup_providers.dart';
 // **************************************************************************
 
 String _$saveEquipmentSetupHash() =>
-    r'eeb18d15598e5ae048c7f6c027a337be61a338ba';
+    r'bde677b91909ace410351d6ed1b0c1f82da7258a';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -268,7 +268,7 @@ class _SaveEquipmentSetupProviderElement
 }
 
 String _$exportEquipmentSetupHash() =>
-    r'8b63aa8b1a112ef1a580db187bebc1e3e78f0113';
+    r'00e637d3be31a5d9b5e30f509d7c6858f2f47769';
 
 /// A provider for exporting [setup] to a file.
 ///
@@ -509,7 +509,7 @@ class _ExportEquipmentSetupProviderElement
 }
 
 String _$savedEquipmentSetupsHash() =>
-    r'b28d981ab200ba87502288e3e9ad1336f2be4006';
+    r'9f6bfefb83f7c9da8e0d24d3861b25b2e5cb2d2a';
 
 /// A provider for reading and holding all the saved [EquipmentSetup]s in the
 /// user file directory.
@@ -529,7 +529,7 @@ final savedEquipmentSetupsProvider =
 
 typedef SavedEquipmentSetupsRef = FutureProviderRef<List<EquipmentSetup>>;
 String _$deleteEquipmentSetupHash() =>
-    r'606fc12bca98c2e8c9b7563205e0a79dbdc6e114';
+    r'3b19dbf88d3dfa02f8c0389a9c7d41f440bdbfe0';
 
 /// A provider for deleting [setup] form the user file system.
 ///

--- a/lib/src/features/guidance/models/path_tracking/stanley_path_tracking/stanley_parameters.freezed.dart
+++ b/lib/src/features/guidance/models/path_tracking/stanley_path_tracking/stanley_parameters.freezed.dart
@@ -130,7 +130,7 @@ class __$$StanleyParametersImplCopyWithImpl<$Res>
 class _$StanleyParametersImpl implements _StanleyParameters {
   const _$StanleyParametersImpl(
       {this.crossDistanceGain = 1.5,
-      this.softeningGain = 0.00001,
+      this.softeningGain = 1e-5,
       this.velocityGain = 1.3});
 
   factory _$StanleyParametersImpl.fromJson(Map<String, dynamic> json) =>

--- a/lib/src/features/guidance/models/path_tracking/stanley_path_tracking/stanley_parameters.g.dart
+++ b/lib/src/features/guidance/models/path_tracking/stanley_path_tracking/stanley_parameters.g.dart
@@ -10,7 +10,7 @@ _$StanleyParametersImpl _$$StanleyParametersImplFromJson(
         Map<String, dynamic> json) =>
     _$StanleyParametersImpl(
       crossDistanceGain: (json['crossDistanceGain'] as num?)?.toDouble() ?? 1.5,
-      softeningGain: (json['softeningGain'] as num?)?.toDouble() ?? 0.00001,
+      softeningGain: (json['softeningGain'] as num?)?.toDouble() ?? 1e-5,
       velocityGain: (json['velocityGain'] as num?)?.toDouble() ?? 1.3,
     );
 

--- a/lib/src/features/guidance/providers/path_recording_providers.g.dart
+++ b/lib/src/features/guidance/providers/path_recording_providers.g.dart
@@ -175,7 +175,7 @@ final showFinishedPathProvider =
 );
 
 typedef _$ShowFinishedPath = Notifier<bool>;
-String _$editFinishedPathHash() => r'14c7b55229f2a230ab4c0ac547ea871e1b2fa22e';
+String _$editFinishedPathHash() => r'a29a27f1b18455d4744258a9ed7dba5bd68d2b47';
 
 /// Whether to activate editing of the last finished path recording.
 ///

--- a/lib/src/features/hardware/models/imu/imu_reading.g.dart
+++ b/lib/src/features/hardware/models/imu/imu_reading.g.dart
@@ -8,7 +8,8 @@ part of 'imu_reading.dart';
 
 _$ImuReadingImpl _$$ImuReadingImplFromJson(Map<String, dynamic> json) =>
     _$ImuReadingImpl(
-      receiveTime: DateTime.parse(json['receiveTime'] as String),
+      receiveTime:
+          const DateTimeSerializer().fromJson(json['receiveTime'] as String),
       yaw: json['yaw'] as num? ?? 0,
       pitch: json['pitch'] as num? ?? 0,
       roll: json['roll'] as num? ?? 0,
@@ -19,7 +20,7 @@ _$ImuReadingImpl _$$ImuReadingImplFromJson(Map<String, dynamic> json) =>
 
 Map<String, dynamic> _$$ImuReadingImplToJson(_$ImuReadingImpl instance) =>
     <String, dynamic>{
-      'receiveTime': instance.receiveTime.toIso8601String(),
+      'receiveTime': const DateTimeSerializer().toJson(instance.receiveTime),
       'yaw': instance.yaw,
       'pitch': instance.pitch,
       'roll': instance.roll,

--- a/lib/src/features/hardware/models/message_decoder.dart
+++ b/lib/src/features/hardware/models/message_decoder.dart
@@ -406,12 +406,19 @@ class MessageDecoder {
               if (_logIMU && logDirectoryPath != null) {
                 _imuLogStartTime ??= DateTime.now();
                 final file = File(
-                  '$logDirectoryPath/imu/${_imuLogStartTime!.toIso8601String()}.log',
+                  [
+                    logDirectoryPath,
+                    'imu',
+                    '${_imuLogStartTime!.toIso8601String()}.log',
+                  ].join(Platform.pathSeparator),
                 );
                 if (!file.existsSync()) {
                   file.createSync(recursive: true);
                 }
-                file.writeAsStringSync('$reading\n', mode: FileMode.append);
+                file.writeAsStringSync(
+                  [reading, Platform.lineTerminator,].join(),
+                  mode: FileMode.append,
+                );
               }
             }
           }
@@ -436,12 +443,22 @@ class MessageDecoder {
               if (_logWAS && logDirectoryPath != null) {
                 _wasLogStartTime ??= DateTime.now();
                 final file = File(
-                  '$logDirectoryPath/was/${_wasLogStartTime!.toIso8601String()}.log',
+                  [
+                    logDirectoryPath,
+                    'was',
+                    '${_wasLogStartTime!.toIso8601String()}.log',
+                  ].join(Platform.pathSeparator),
                 );
                 if (!file.existsSync()) {
                   file.createSync(recursive: true);
                 }
-                file.writeAsStringSync('$reading\n', mode: FileMode.append);
+                file.writeAsStringSync(
+                  [
+                    reading,
+                    Platform.lineTerminator,
+                  ].join(),
+                  mode: FileMode.append,
+                );
               }
             }
           }
@@ -587,13 +604,20 @@ class MessageDecoder {
         if (_logGNSS && logDirectoryPath != null) {
           _gnssLogStartTime ??= DateTime.now();
           final file = File(
-            '$logDirectoryPath/gnss/${_gnssLogStartTime!.toIso8601String()}.log',
+            [
+              logDirectoryPath,
+              'gnss',
+              '${_gnssLogStartTime!.toIso8601String()}.log',
+            ].join(Platform.pathSeparator),
           );
           if (!file.existsSync()) {
             file.createSync(recursive: true);
           }
           file.writeAsStringSync(
-            '${DateTime.now().toIso8601String()}: ${nmea?.raw}\n',
+            [
+              '${DateTime.now().toIso8601String()}: ${nmea?.raw}',
+              Platform.lineTerminator,
+            ].join(),
             mode: FileMode.append,
           );
         }
@@ -611,13 +635,20 @@ class MessageDecoder {
       if (_logCombined && logDirectoryPath != null) {
         _combinedLogStartTime ??= DateTime.now();
         final file = File(
-          '$logDirectoryPath/combined/${_combinedLogStartTime!.toIso8601String()}.log',
+          [
+            logDirectoryPath,
+            'combined',
+            '${_combinedLogStartTime!.toIso8601String()}.log',
+          ].join(Platform.pathSeparator),
         );
         if (!file.existsSync()) {
           file.createSync(recursive: true);
         }
         file.writeAsStringSync(
-          '${DateTime.now().toIso8601String()}: $str\n',
+          [
+            '${DateTime.now().toIso8601String()}: $str',
+            Platform.lineTerminator,
+          ].join(),
           mode: FileMode.append,
         );
       }

--- a/lib/src/features/hardware/models/was/was_reading.g.dart
+++ b/lib/src/features/hardware/models/was/was_reading.g.dart
@@ -8,12 +8,13 @@ part of 'was_reading.dart';
 
 _$WasReadingImpl _$$WasReadingImplFromJson(Map<String, dynamic> json) =>
     _$WasReadingImpl(
-      receiveTime: DateTime.parse(json['receiveTime'] as String),
+      receiveTime:
+          const DateTimeSerializer().fromJson(json['receiveTime'] as String),
       value: (json['value'] as num?)?.toInt() ?? 0,
     );
 
 Map<String, dynamic> _$$WasReadingImplToJson(_$WasReadingImpl instance) =>
     <String, dynamic>{
-      'receiveTime': instance.receiveTime.toIso8601String(),
+      'receiveTime': const DateTimeSerializer().toJson(instance.receiveTime),
       'value': instance.value,
     };

--- a/lib/src/features/map/models/file_cached_tile_provider.dart
+++ b/lib/src/features/map/models/file_cached_tile_provider.dart
@@ -83,7 +83,7 @@ class FileCachedTileProvider extends TileProvider {
           [
             layerDirectory.path,
             'created',
-          ].join('/'),
+          ].join(Platform.pathSeparator),
         )
           ..createSync(recursive: true)
           ..writeAsStringSync(time.toIso8601String());
@@ -102,7 +102,7 @@ class FileCachedTileProvider extends TileProvider {
                 '${coordinates.z}',
                 '${coordinates.y}',
                 '${coordinates.x}.png',
-              ].join('/'),
+              ].join(Platform.pathSeparator),
             )
           : null,
       allowDownload: allowDownloads,

--- a/lib/src/features/map/models/tile_layer_data.dart
+++ b/lib/src/features/map/models/tile_layer_data.dart
@@ -93,6 +93,6 @@ class TileLayerData {
           'map_image_cache',
           if (folderName != null) folderName,
           name,
-        ].join('/'),
+        ].join(Platform.pathSeparator),
       );
 }

--- a/lib/src/features/map/providers/editable_path_providers.g.dart
+++ b/lib/src/features/map/providers/editable_path_providers.g.dart
@@ -26,7 +26,7 @@ final editablePathAsWayPointsProvider =
 
 typedef EditablePathAsWayPointsRef = AutoDisposeProviderRef<List<WayPoint>?>;
 String _$activeEditablePathTypeHash() =>
-    r'c2a4479bf77a4662c5dac23c2dfe5bde67923fea';
+    r'2259071575a7b5ee68ebdd9ff4e6fee7b9471fa8';
 
 /// A provider for whether the editable path feature should be enabled.
 ///

--- a/lib/src/features/map/providers/map_providers.dart
+++ b/lib/src/features/map/providers/map_providers.dart
@@ -463,7 +463,7 @@ class MapZoom extends _$MapZoom {
 /// at the given [path].
 @riverpod
 FutureOr<DateTime?> mapCacheDate(MapCacheDateRef ref, String path) async {
-  final file = File([path, 'created'].join('/'));
+  final file = File([path, 'created'].join(Platform.pathSeparator));
 
   if (file.existsSync()) {
     return DateTime.tryParse(await file.readAsString());
@@ -478,7 +478,7 @@ FutureOr<List<String>> mapCacheDirectories(MapCacheDirectoriesRef ref) async =>
       [
         ref.watch(fileDirectoryProvider).requireValue.path,
         'map_image_cache',
-      ].join('/'),
+      ].join(Platform.pathSeparator),
     ).findSubfoldersWithTargetFile();
 
 /// Whether the map should be allowed to download tiles over the internet.

--- a/lib/src/features/map/providers/map_providers.g.dart
+++ b/lib/src/features/map/providers/map_providers.g.dart
@@ -41,7 +41,7 @@ final offsetVehiclePositionProvider = AutoDisposeProvider<LatLng>.internal(
 );
 
 typedef OffsetVehiclePositionRef = AutoDisposeProviderRef<LatLng>;
-String _$mapCacheDateHash() => r'0b10a2822bb4319c72710f2de30016f2b501372c';
+String _$mapCacheDateHash() => r'9b324f0312bfcd69326fac1f4d7abaf143acd223';
 
 /// Copied from Dart SDK
 class _SystemHash {
@@ -251,7 +251,7 @@ class _MapCacheDateProviderElement
 }
 
 String _$mapCacheDirectoriesHash() =>
-    r'466efc3812ee4ab6265fa42d67f9be292e413542';
+    r'765cf6cb05cbeed5d5b2f99b328e65a7a100183e';
 
 /// A provider for listing all the map layer cache folders.
 ///

--- a/lib/src/features/map/widgets/map_layers/equipment_worked_paths_layer.dart
+++ b/lib/src/features/map/widgets/map_layers/equipment_worked_paths_layer.dart
@@ -61,22 +61,21 @@ class _EquipmentWorkedPathsLayerState
                   activation.map<int, Float32List>((section, points) {
                 if (points != null) {
                   final offsets = [
-                    for (final offset in points
-                      .map(
-                        (e) {
-                          final offset1 = camera
-                              .latLngToScreenPoint(e.left.latLng)
-                              .toOffset();
-                          final offset2 = camera
-                              .latLngToScreenPoint(e.right.latLng)
-                              .toOffset();
-                          return [
-                            offset1.dx,
-                            offset1.dy,
-                            offset2.dx,
-                            offset2.dy,
-                          ];
-                        },
+                    for (final offset in points.map(
+                      (e) {
+                        final offset1 = camera
+                            .latLngToScreenPoint(e.left.latLng)
+                            .toOffset();
+                        final offset2 = camera
+                            .latLngToScreenPoint(e.right.latLng)
+                            .toOffset();
+                        return [
+                          offset1.dx,
+                          offset1.dy,
+                          offset2.dx,
+                          offset2.dy,
+                        ];
+                      },
                     ))
                       ...offset,
                   ];
@@ -132,7 +131,11 @@ class _EquipmentWorkedPathsLayerState
       return children.first;
     }
 
-    return Stack(children: children);
+    return Stack(
+      children: [
+        ...children,
+      ],
+    );
   }
 }
 

--- a/lib/src/features/map/widgets/map_layers/grid_layer.dart
+++ b/lib/src/features/map/widgets/map_layers/grid_layer.dart
@@ -18,7 +18,6 @@
 import 'dart:math';
 
 import 'package:autosteering/src/features/common/common.dart';
-import 'package:autosteering/src/features/field/field.dart';
 import 'package:autosteering/src/features/map/map.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_map/flutter_map.dart';
@@ -34,9 +33,10 @@ class GridLayer extends ConsumerWidget {
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     final camera = MapCamera.of(context);
-    final origo = ref.watch(
-          activeFieldProvider.select((value) => value?.boundingBox?.min),
-        ) ??
+    final origo =
+        // ref.watch(
+        //       activeFieldProvider.select((value) => value?.boundingBox?.min),
+        //     ) ??
         ref.watch(homePositionProvider).gbPosition;
 
     final vertical = Grid.verticalLines(origo, camera);

--- a/lib/src/features/map/widgets/map_menu/delete_cache_menu.dart
+++ b/lib/src/features/map/widgets/map_menu/delete_cache_menu.dart
@@ -15,12 +15,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Autosteering.  If not, see <https://www.gnu.org/licenses/>.
 
+
 import 'package:autosteering/src/features/common/common.dart';
 import 'package:autosteering/src/features/map/map.dart';
 import 'package:autosteering/src/features/theme/utils/menu_button_text_extension.dart';
 import 'package:fast_cached_network_image/fast_cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:universal_io/io.dart';
 
 /// A menu/button for for deleting map layer caches.
 ///
@@ -78,7 +80,7 @@ class _CacheDeleter extends ConsumerWidget {
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
-    final pathSplit = path.split('/').reversed;
+    final pathSplit = path.split(Platform.pathSeparator).reversed;
 
     return MenuItemButton(
       closeOnActivate: false,

--- a/lib/src/features/simulator/models/log_replay.dart
+++ b/lib/src/features/simulator/models/log_replay.dart
@@ -16,6 +16,7 @@
 // along with Autosteering.  If not, see <https://www.gnu.org/licenses/>.
 
 import 'dart:async';
+import 'dart:convert';
 
 import 'package:collection/collection.dart';
 
@@ -30,8 +31,8 @@ class LogReplay {
   /// [loop] is whehter the log should restart when reaching the end.
   factory LogReplay({required String log, bool loop = false}) {
     DateTime? firstRecordTime;
-    final records = log
-        .split('\n')
+    final records = const LineSplitter()
+        .convert(log)
         .where((element) => element.isNotEmpty && element.contains(':'))
         .mapIndexed((index, raw) {
       final record = LogReplayRecord(

--- a/lib/src/features/simulator/models/simulator_core_native.dart
+++ b/lib/src/features/simulator/models/simulator_core_native.dart
@@ -361,8 +361,10 @@ class SimulatorCore {
           BackgroundIsolateBinaryMessenger.ensureInitialized(message);
           final logDirectoryPath = [
             (await getApplicationDocumentsDirectory()).path,
-            '/Autosteering/logs/hardware',
-          ].join();
+            'Autosteering',
+            'logs',
+            'hardware',
+          ].join(Platform.pathSeparator);
           messageDecoder = MessageDecoder(logDirectoryPath: logDirectoryPath);
         }
         // Close and remote UDP instances if no network is available, stops

--- a/lib/src/features/work_session/providers/work_session_providers.g.dart
+++ b/lib/src/features/work_session/providers/work_session_providers.g.dart
@@ -212,7 +212,7 @@ class _LoadWorkSessionFromFileProviderElement
   String get path => (origin as LoadWorkSessionFromFileProvider).path;
 }
 
-String _$saveWorkSessionHash() => r'82178e6440b264bc6fe4d110847a5ecef0baecf0';
+String _$saveWorkSessionHash() => r'947bad0366aa976655c9794c66c35133d03d35a8';
 
 /// A provider for saving [workSession] to a file in the user file directory.
 ///
@@ -450,7 +450,270 @@ class _SaveWorkSessionProviderElement
   bool get downloadIfWeb => (origin as SaveWorkSessionProvider).downloadIfWeb;
 }
 
-String _$exportWorkSessionHash() => r'0c2beb6a966f97b31c71a3d6acf411d084106e74';
+String _$saveWorkSessionEquipmentLogsHash() =>
+    r'caf29764addc500b0719b8bd9a600aea09165b93';
+
+/// A provider for saving the [workSession]s [WorkSession.equipmentLogs] to
+/// their respective files.
+///
+/// Set the [overwrite] parameter to false to preserve already existing files.
+/// [singleUuid] can be used to specify a single equipment's logs that should
+/// be saved.
+///
+/// Copied from [saveWorkSessionEquipmentLogs].
+@ProviderFor(saveWorkSessionEquipmentLogs)
+const saveWorkSessionEquipmentLogsProvider =
+    SaveWorkSessionEquipmentLogsFamily();
+
+/// A provider for saving the [workSession]s [WorkSession.equipmentLogs] to
+/// their respective files.
+///
+/// Set the [overwrite] parameter to false to preserve already existing files.
+/// [singleUuid] can be used to specify a single equipment's logs that should
+/// be saved.
+///
+/// Copied from [saveWorkSessionEquipmentLogs].
+class SaveWorkSessionEquipmentLogsFamily extends Family {
+  /// A provider for saving the [workSession]s [WorkSession.equipmentLogs] to
+  /// their respective files.
+  ///
+  /// Set the [overwrite] parameter to false to preserve already existing files.
+  /// [singleUuid] can be used to specify a single equipment's logs that should
+  /// be saved.
+  ///
+  /// Copied from [saveWorkSessionEquipmentLogs].
+  const SaveWorkSessionEquipmentLogsFamily();
+
+  static const Iterable<ProviderOrFamily>? _dependencies = null;
+
+  static const Iterable<ProviderOrFamily>? _allTransitiveDependencies = null;
+
+  @override
+  Iterable<ProviderOrFamily>? get dependencies => _dependencies;
+
+  @override
+  Iterable<ProviderOrFamily>? get allTransitiveDependencies =>
+      _allTransitiveDependencies;
+
+  @override
+  String? get name => r'saveWorkSessionEquipmentLogsProvider';
+
+  /// A provider for saving the [workSession]s [WorkSession.equipmentLogs] to
+  /// their respective files.
+  ///
+  /// Set the [overwrite] parameter to false to preserve already existing files.
+  /// [singleUuid] can be used to specify a single equipment's logs that should
+  /// be saved.
+  ///
+  /// Copied from [saveWorkSessionEquipmentLogs].
+  SaveWorkSessionEquipmentLogsProvider call(
+    WorkSession workSession, {
+    bool overwrite = true,
+    String? singleUuid,
+  }) {
+    return SaveWorkSessionEquipmentLogsProvider(
+      workSession,
+      overwrite: overwrite,
+      singleUuid: singleUuid,
+    );
+  }
+
+  @visibleForOverriding
+  @override
+  SaveWorkSessionEquipmentLogsProvider getProviderOverride(
+    covariant SaveWorkSessionEquipmentLogsProvider provider,
+  ) {
+    return call(
+      provider.workSession,
+      overwrite: provider.overwrite,
+      singleUuid: provider.singleUuid,
+    );
+  }
+
+  /// Enables overriding the behavior of this provider, no matter the parameters.
+  Override overrideWith(
+      FutureOr<void> Function(SaveWorkSessionEquipmentLogsRef ref) create) {
+    return _$SaveWorkSessionEquipmentLogsFamilyOverride(this, create);
+  }
+}
+
+class _$SaveWorkSessionEquipmentLogsFamilyOverride implements FamilyOverride {
+  _$SaveWorkSessionEquipmentLogsFamilyOverride(
+      this.overriddenFamily, this.create);
+
+  final FutureOr<void> Function(SaveWorkSessionEquipmentLogsRef ref) create;
+
+  @override
+  final SaveWorkSessionEquipmentLogsFamily overriddenFamily;
+
+  @override
+  SaveWorkSessionEquipmentLogsProvider getProviderOverride(
+    covariant SaveWorkSessionEquipmentLogsProvider provider,
+  ) {
+    return provider._copyWith(create);
+  }
+}
+
+/// A provider for saving the [workSession]s [WorkSession.equipmentLogs] to
+/// their respective files.
+///
+/// Set the [overwrite] parameter to false to preserve already existing files.
+/// [singleUuid] can be used to specify a single equipment's logs that should
+/// be saved.
+///
+/// Copied from [saveWorkSessionEquipmentLogs].
+class SaveWorkSessionEquipmentLogsProvider
+    extends AutoDisposeFutureProvider<void> {
+  /// A provider for saving the [workSession]s [WorkSession.equipmentLogs] to
+  /// their respective files.
+  ///
+  /// Set the [overwrite] parameter to false to preserve already existing files.
+  /// [singleUuid] can be used to specify a single equipment's logs that should
+  /// be saved.
+  ///
+  /// Copied from [saveWorkSessionEquipmentLogs].
+  SaveWorkSessionEquipmentLogsProvider(
+    WorkSession workSession, {
+    bool overwrite = true,
+    String? singleUuid,
+  }) : this._internal(
+          (ref) => saveWorkSessionEquipmentLogs(
+            ref as SaveWorkSessionEquipmentLogsRef,
+            workSession,
+            overwrite: overwrite,
+            singleUuid: singleUuid,
+          ),
+          from: saveWorkSessionEquipmentLogsProvider,
+          name: r'saveWorkSessionEquipmentLogsProvider',
+          debugGetCreateSourceHash:
+              const bool.fromEnvironment('dart.vm.product')
+                  ? null
+                  : _$saveWorkSessionEquipmentLogsHash,
+          dependencies: SaveWorkSessionEquipmentLogsFamily._dependencies,
+          allTransitiveDependencies:
+              SaveWorkSessionEquipmentLogsFamily._allTransitiveDependencies,
+          workSession: workSession,
+          overwrite: overwrite,
+          singleUuid: singleUuid,
+        );
+
+  SaveWorkSessionEquipmentLogsProvider._internal(
+    super.create, {
+    required super.name,
+    required super.dependencies,
+    required super.allTransitiveDependencies,
+    required super.debugGetCreateSourceHash,
+    required super.from,
+    required this.workSession,
+    required this.overwrite,
+    required this.singleUuid,
+  }) : super.internal();
+
+  final WorkSession workSession;
+  final bool overwrite;
+  final String? singleUuid;
+
+  @override
+  Override overrideWith(
+    FutureOr<void> Function(SaveWorkSessionEquipmentLogsRef ref) create,
+  ) {
+    return ProviderOverride(
+      origin: this,
+      override: SaveWorkSessionEquipmentLogsProvider._internal(
+        (ref) => create(ref as SaveWorkSessionEquipmentLogsRef),
+        from: from,
+        name: null,
+        dependencies: null,
+        allTransitiveDependencies: null,
+        debugGetCreateSourceHash: null,
+        workSession: workSession,
+        overwrite: overwrite,
+        singleUuid: singleUuid,
+      ),
+    );
+  }
+
+  @override
+  (
+    WorkSession, {
+    bool overwrite,
+    String? singleUuid,
+  }) get argument {
+    return (
+      workSession,
+      overwrite: overwrite,
+      singleUuid: singleUuid,
+    );
+  }
+
+  @override
+  AutoDisposeFutureProviderElement<void> createElement() {
+    return _SaveWorkSessionEquipmentLogsProviderElement(this);
+  }
+
+  SaveWorkSessionEquipmentLogsProvider _copyWith(
+    FutureOr<void> Function(SaveWorkSessionEquipmentLogsRef ref) create,
+  ) {
+    return SaveWorkSessionEquipmentLogsProvider._internal(
+      (ref) => create(ref as SaveWorkSessionEquipmentLogsRef),
+      name: name,
+      dependencies: dependencies,
+      allTransitiveDependencies: allTransitiveDependencies,
+      debugGetCreateSourceHash: debugGetCreateSourceHash,
+      from: from,
+      workSession: workSession,
+      overwrite: overwrite,
+      singleUuid: singleUuid,
+    );
+  }
+
+  @override
+  bool operator ==(Object other) {
+    return other is SaveWorkSessionEquipmentLogsProvider &&
+        other.workSession == workSession &&
+        other.overwrite == overwrite &&
+        other.singleUuid == singleUuid;
+  }
+
+  @override
+  int get hashCode {
+    var hash = _SystemHash.combine(0, runtimeType.hashCode);
+    hash = _SystemHash.combine(hash, workSession.hashCode);
+    hash = _SystemHash.combine(hash, overwrite.hashCode);
+    hash = _SystemHash.combine(hash, singleUuid.hashCode);
+
+    return _SystemHash.finish(hash);
+  }
+}
+
+mixin SaveWorkSessionEquipmentLogsRef on AutoDisposeFutureProviderRef<void> {
+  /// The parameter `workSession` of this provider.
+  WorkSession get workSession;
+
+  /// The parameter `overwrite` of this provider.
+  bool get overwrite;
+
+  /// The parameter `singleUuid` of this provider.
+  String? get singleUuid;
+}
+
+class _SaveWorkSessionEquipmentLogsProviderElement
+    extends AutoDisposeFutureProviderElement<void>
+    with SaveWorkSessionEquipmentLogsRef {
+  _SaveWorkSessionEquipmentLogsProviderElement(super.provider);
+
+  @override
+  WorkSession get workSession =>
+      (origin as SaveWorkSessionEquipmentLogsProvider).workSession;
+  @override
+  bool get overwrite =>
+      (origin as SaveWorkSessionEquipmentLogsProvider).overwrite;
+  @override
+  String? get singleUuid =>
+      (origin as SaveWorkSessionEquipmentLogsProvider).singleUuid;
+}
+
+String _$exportWorkSessionHash() => r'fb3ff5314e651b2cc9a65a6c6ec3c4dcb55e246d';
 
 /// A provider for exporting [workSession] to a file.
 ///
@@ -496,11 +759,13 @@ class ExportWorkSessionFamily extends Family {
     WorkSession workSession, {
     String? overrideName,
     bool downloadIfWeb = false,
+    bool withEquipmentLogs = true,
   }) {
     return ExportWorkSessionProvider(
       workSession,
       overrideName: overrideName,
       downloadIfWeb: downloadIfWeb,
+      withEquipmentLogs: withEquipmentLogs,
     );
   }
 
@@ -513,6 +778,7 @@ class ExportWorkSessionFamily extends Family {
       provider.workSession,
       overrideName: provider.overrideName,
       downloadIfWeb: provider.downloadIfWeb,
+      withEquipmentLogs: provider.withEquipmentLogs,
     );
   }
 
@@ -554,12 +820,14 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
     WorkSession workSession, {
     String? overrideName,
     bool downloadIfWeb = false,
+    bool withEquipmentLogs = true,
   }) : this._internal(
           (ref) => exportWorkSession(
             ref as ExportWorkSessionRef,
             workSession,
             overrideName: overrideName,
             downloadIfWeb: downloadIfWeb,
+            withEquipmentLogs: withEquipmentLogs,
           ),
           from: exportWorkSessionProvider,
           name: r'exportWorkSessionProvider',
@@ -573,6 +841,7 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
           workSession: workSession,
           overrideName: overrideName,
           downloadIfWeb: downloadIfWeb,
+          withEquipmentLogs: withEquipmentLogs,
         );
 
   ExportWorkSessionProvider._internal(
@@ -585,11 +854,13 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
     required this.workSession,
     required this.overrideName,
     required this.downloadIfWeb,
+    required this.withEquipmentLogs,
   }) : super.internal();
 
   final WorkSession workSession;
   final String? overrideName;
   final bool downloadIfWeb;
+  final bool withEquipmentLogs;
 
   @override
   Override overrideWith(
@@ -607,6 +878,7 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
         workSession: workSession,
         overrideName: overrideName,
         downloadIfWeb: downloadIfWeb,
+        withEquipmentLogs: withEquipmentLogs,
       ),
     );
   }
@@ -616,11 +888,13 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
     WorkSession, {
     String? overrideName,
     bool downloadIfWeb,
+    bool withEquipmentLogs,
   }) get argument {
     return (
       workSession,
       overrideName: overrideName,
       downloadIfWeb: downloadIfWeb,
+      withEquipmentLogs: withEquipmentLogs,
     );
   }
 
@@ -642,6 +916,7 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
       workSession: workSession,
       overrideName: overrideName,
       downloadIfWeb: downloadIfWeb,
+      withEquipmentLogs: withEquipmentLogs,
     );
   }
 
@@ -650,7 +925,8 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
     return other is ExportWorkSessionProvider &&
         other.workSession == workSession &&
         other.overrideName == overrideName &&
-        other.downloadIfWeb == downloadIfWeb;
+        other.downloadIfWeb == downloadIfWeb &&
+        other.withEquipmentLogs == withEquipmentLogs;
   }
 
   @override
@@ -659,6 +935,7 @@ class ExportWorkSessionProvider extends AutoDisposeFutureProvider<void> {
     hash = _SystemHash.combine(hash, workSession.hashCode);
     hash = _SystemHash.combine(hash, overrideName.hashCode);
     hash = _SystemHash.combine(hash, downloadIfWeb.hashCode);
+    hash = _SystemHash.combine(hash, withEquipmentLogs.hashCode);
 
     return _SystemHash.finish(hash);
   }
@@ -673,6 +950,9 @@ mixin ExportWorkSessionRef on AutoDisposeFutureProviderRef<void> {
 
   /// The parameter `downloadIfWeb` of this provider.
   bool get downloadIfWeb;
+
+  /// The parameter `withEquipmentLogs` of this provider.
+  bool get withEquipmentLogs;
 }
 
 class _ExportWorkSessionProviderElement
@@ -687,9 +967,12 @@ class _ExportWorkSessionProviderElement
       (origin as ExportWorkSessionProvider).overrideName;
   @override
   bool get downloadIfWeb => (origin as ExportWorkSessionProvider).downloadIfWeb;
+  @override
+  bool get withEquipmentLogs =>
+      (origin as ExportWorkSessionProvider).withEquipmentLogs;
 }
 
-String _$savedWorkSessionsHash() => r'd2ab4bc851392f153d3a832b6c44059198f41e4e';
+String _$savedWorkSessionsHash() => r'0a7005b98eef7ecfe11a8031ce10833223609459';
 
 /// A provider for reading and holding all the saved [WorkSession]s in the
 /// user file directory.
@@ -707,11 +990,11 @@ final savedWorkSessionsProvider = FutureProvider<List<WorkSession>>.internal(
 );
 
 typedef SavedWorkSessionsRef = FutureProviderRef<List<WorkSession>>;
-String _$deleteWorkSessionHash() => r'6a484bceb01997d0795100cf22353a6e11b657f2';
+String _$deleteWorkSessionHash() => r'65cc4a7123ad600558056f806c8731a44240f0fb';
 
 /// A provider for deleting [workSession] from the user file system.
 ///
-/// Override the file name with [overrideName].
+/// Override the directory name with [overrideName].
 ///
 /// Copied from [deleteWorkSession].
 @ProviderFor(deleteWorkSession)
@@ -719,13 +1002,13 @@ const deleteWorkSessionProvider = DeleteWorkSessionFamily();
 
 /// A provider for deleting [workSession] from the user file system.
 ///
-/// Override the file name with [overrideName].
+/// Override the directory name with [overrideName].
 ///
 /// Copied from [deleteWorkSession].
 class DeleteWorkSessionFamily extends Family {
   /// A provider for deleting [workSession] from the user file system.
   ///
-  /// Override the file name with [overrideName].
+  /// Override the directory name with [overrideName].
   ///
   /// Copied from [deleteWorkSession].
   const DeleteWorkSessionFamily();
@@ -746,7 +1029,7 @@ class DeleteWorkSessionFamily extends Family {
 
   /// A provider for deleting [workSession] from the user file system.
   ///
-  /// Override the file name with [overrideName].
+  /// Override the directory name with [overrideName].
   ///
   /// Copied from [deleteWorkSession].
   DeleteWorkSessionProvider call(
@@ -795,13 +1078,13 @@ class _$DeleteWorkSessionFamilyOverride implements FamilyOverride {
 
 /// A provider for deleting [workSession] from the user file system.
 ///
-/// Override the file name with [overrideName].
+/// Override the directory name with [overrideName].
 ///
 /// Copied from [deleteWorkSession].
 class DeleteWorkSessionProvider extends AutoDisposeFutureProvider<void> {
   /// A provider for deleting [workSession] from the user file system.
   ///
-  /// Override the file name with [overrideName].
+  /// Override the directory name with [overrideName].
   ///
   /// Copied from [deleteWorkSession].
   DeleteWorkSessionProvider(
@@ -927,7 +1210,7 @@ class _DeleteWorkSessionProviderElement
       (origin as DeleteWorkSessionProvider).overrideName;
 }
 
-String _$importWorkSessionHash() => r'0ed6ba27fe2538180d74960e61d7b88d643a3b92';
+String _$importWorkSessionHash() => r'ba6c4595c03b7f18e63873270b7487012bc1469c';
 
 /// A provider for importing a work session from a file and applying it
 /// to the [ActiveWorkSession] provider.
@@ -1131,7 +1414,7 @@ class _ExportWorkSessionsProviderElement
   bool get zip => (origin as ExportWorkSessionsProvider).zip;
 }
 
-String _$activeWorkSessionHash() => r'96a702a8b386aa5dd813e30959b6681373746630';
+String _$activeWorkSessionHash() => r'f16bb30c8990506861463f165a8b09cad4a8899f';
 
 /// A provider for holding the active [WorkSession].
 ///


### PR DESCRIPTION
Work session worked paths are now stored in separate equipment log files for each equipment.
Reduces size by a lot (up to 10x or more) by only logging the positon, bearing, section status and time of the equipment
instead of positions for all sections. The worked paths are calculated after loading the files.